### PR TITLE
Bumping compute node count to 9

### DIFF
--- a/templates/openshift-master.template
+++ b/templates/openshift-master.template
@@ -295,7 +295,7 @@ Parameters:
     Type: Number
     AllowedValues: [ '3' ]
   NumberOfNodes:
-    Default: '3'
+    Default: '9'
     Description: The desired capacity for the OpenShift node instances
     Type: Number
   OutputBucketName:

--- a/templates/openshift.template
+++ b/templates/openshift.template
@@ -288,7 +288,7 @@ Parameters:
     AllowedValues:
       - '3'
   NumberOfNodes:
-    Default: '3'
+    Default: '9'
     Description: The desired capacity for the OpenShift node instances
     Type: Number
   OutputBucketName:


### PR DESCRIPTION
**Summary**
Bumping compute node count to 9 to align ourselves with the OSD 3.11 offering (3 nodes per AZ).